### PR TITLE
Fix passed function argument in jpegdropscan

### DIFF
--- a/jpegdropscan.pl
+++ b/jpegdropscan.pl
@@ -196,7 +196,7 @@ sub shavebits() {
             last;
           }
         }
-        if ($skip || checkbest @s == -1) {
+        if ($skip || checkbest(@s) == -1) {
           my ($p, $q) = @{$s[$s]}[1, 2];
           if ($p < $q) {
             $s[$s][4] = $b - 1;


### PR DESCRIPTION
Disclaimer: I don't know perl, so I'm not sure if this is correct.

Running jpegdropscan would result in the following error message:
```
Can't use string ("") as an ARRAY ref while "strict refs" in use at jpegdropscan.pl line 139.
```
I think this call to checkbest was receiving the result of `@s == -1` instead of `@s`. Applying this change seems to fix jpegdropscan for me.
